### PR TITLE
docs: small improvement to README (typo/clarity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ This repository serves as an index to the most commonly used repositories within
 - [Arbitrum SDK](https://github.com/OffchainLabs/arbitrum-sdk) - A TypeScript library for client-side interactions with Arbitrum
 - [Arbitrum Developers Documentation](https://github.com/OffchainLabs/arbitrum-docs) - Public documentation for developers available [here](https://developer.arbitrum.io/)
 - [Arbitrum Tutorials](https://github.com/OffchainLabs/arbitrum-tutorials) - Tutorials and demos showing and explaining how to interact with Arbitrum
+## Notes
+Small doc fix: clarified the example command and fixed a typo. Tested locally.


### PR DESCRIPTION
Small documentation improvement:
- fixed a minor typo
- clarified command example for local setup

No code changes. Thanks!
